### PR TITLE
いいねとコメントの表示崩れの修正

### DIFF
--- a/app/assets/stylesheets/templates/_posts.scss
+++ b/app/assets/stylesheets/templates/_posts.scss
@@ -100,7 +100,7 @@
             padding: 0 12px;
             cursor: pointer;
             & li {
-              width: 40px;
+              width: 46px;
               margin-right: 80px;
               & span {
                 font-size: $font_size_defalt;
@@ -188,8 +188,12 @@
   }
   .post_notliked {
     color: black;
+    display: inline-block;
+    margin-left: 4px;
   }
   .post_liked {
     color: $color_actioned;
+    display: inline-block;
+    margin-left: 4px;
   }
 }


### PR DESCRIPTION
投稿一覧画面、投稿詳細画面においての下記2点の表示崩れを修正しました。
- コメントアイコンのカウント数が2桁になった際に改行されている
- いいねとカウント数との間に余白がない。

ご確認よろしくお願い致します！